### PR TITLE
Implement full model finetuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ If you find `pie` useful, please use the following reference:
 
 ## 1. Installation
 
-PIE is available from pypi, which means that all you should need to do is:
+PIE is available from pypi (`pip install nlp-pie`), yet this fork has no published package on PyPI, so you should do:
 
 ```bash
-pip install nlp-pie
+git clone https://github.com/lascivaroma/PaPie.git
+cd PaPie
+pip install .
 ```
+
 
 ### For development
 
@@ -147,6 +150,8 @@ Training a model only requires a model specification and paths to training and d
   "cemb_layers": 2
 }
 ```
+
+All options as well as default values are stored in [`./pie/default_settings.json`](./pie/default_settings.json)
 
 The very minimum set of options required to train a model includes `input_path` (path to files with training data), `dev_path` (path to files with development data), and `tasks`, which defines the model to be trained. Other parameters refer to model hyperparameters (`cell`, `num_layers`, `hidden_size`, `wemb_dim`, `cemb_dim`, `cemb_type`, `cemb_layers`), training (`batch_size`, `epochs`) and optimization (`dropout`, `optimizer`, `patience`, `lr`, `lr_factor`, `lr_patience).
 
@@ -288,3 +293,41 @@ Multi-task learning consists on jointly training a model for different tasks whi
 Additionally, it is also important, in case of a multi-layer sentence-level feature extractor, to select at what layer a particular task can help the most (this can be controlled with the "layer" option).
 
 Finally, multi-task learning is far from being a silver bullet and it is an empirical question whether a multi-task learning setup will yield improvements. It is recommended to first train a single model, and then try different multi-task learning configuration to see if improvements can be achieved.
+
+## 9. Fine-tuning [New !]
+
+Fine-tuning a PIE model (for cases like domain adaptation or transfer to a similar language for instance) is possible with the option `load_pretrained_model` of the config file.
+
+For example:
+
+```json
+{
+  "load_pretrained_model": {
+      "pretrained": "path/to/pie_model.tar",
+      "labels_mode": "replace",
+      "exclude": ["pos"]
+  },
+}
+```
+
+Sub-option **"labels_mode"** indicates how to adapt the vocabularies of the parent model (characters, words, target labels) for the child model. Available values are:
+- *"replace"*: do not use the parent vocabularies, instead compute new ones from the finetuning data and use them
+- *"expand"* (default): keep all parent vocabularies, and if the values indicated by options `word_max_size`, `char_max_size`, `word_min_freq` and `char_min_freq` permit it, append new entries (chars/words/labels) based on the finetuning data (`input_data`)
+  - *e.g. the parent model was trained on 1M words, `word_max_size` was set to 10000 and the vocabulary contains 9000 words. You can finetune with `"labels_mode": "expand"` and `"word_max_size": 10000` to include 1000 new words, or increase `"word_max_size": 20000` to include more new words from the finetuning data*
+- *"replace_fill"*: similar to "expand", except we first replace the vocabulary with a new one computed from the finetuning data, and then we fill the seats left with the parent vocabularies (in order of frequency, depending on options `word_max_size`, `char_max_size`, `word_min_freq` and `char_min_freq`)
+- *"skip"*: keep all parent vocabularies, and only set new ones if the child model will be trained on new task(s)
+  - *e.g. the parent model was trained for POS tagging and the child model will be trained for lemmatization. The parent model does not have a target characters vocabulary for the lemmatization task, so PIE will create only this one, and keep the parent ones for the rest (input characters, words)*
+
+Sub-option **"exclude"** can be used to control which layers (state_dict weights) should be loaded or not. Possible values are: "wemb", "cemb", "cemb_rnn", "sent_rnn", "lm" as well as any target task (e.g. "pos", "lemma"). Excluded modules will be left with the default initialization until training starts.
+
+The config options related to the model architecture (`wemb_dim`, `cemb_dim`, `cemb_type`, `cemb_layers`, `linear_layers`, `hidden_size`, `num_layers` and `cell`) must be the same as the parent model. You can run the following scrip to get this information:
+
+```bash
+python ./scripts/get_pie_model_params.py path/to/model.tar
+```
+
+The fine-tuning command is the same as for training: 
+
+```bash
+pie train path/to/config.json
+```

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ If you find `pie` useful, please use the following reference:
 
 ## 1. Installation
 
-PIE is available from pypi (`pip install nlp-pie`), yet this fork has no published package on PyPI, so you should do:
+PIE is available from pypi: `pip install PaPie`
+
+You can also install it from source:
 
 ```bash
 git clone https://github.com/lascivaroma/PaPie.git

--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -203,10 +203,10 @@ class LabelEncoder(object):
                     f"({size_original_vocab_noreserved} > {self.max_size}: "
                     f"removing {nb_indexes_to_remove} entries to the vocabulary"
                 )
-                self.inverse_table = self.inverse_table[:nb_indexes_to_remove]
+                self.inverse_table = self.inverse_table[:self.max_size+len(self.reserved)]
                 self.table = {
                     sym: idx for i, (sym, idx) in enumerate(self.table.items())
-                    if i < len(self.inverse_table) - nb_indexes_to_remove
+                    if i < self.max_size+len(self.reserved)
                 }
                 self.fitted = True
                 return

--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -429,6 +429,10 @@ class MultiLabelEncoder(object):
         self.nsents = None
         self.noise_strategies = noise_strategies or {}
 
+    @property
+    def all_label_encoders(self):
+        return [self.word, self.char] + list(self.tasks.values())
+
     def __repr__(self):
         return (
             '<MultiLabelEncoder>\n\t' +
@@ -496,24 +500,24 @@ class MultiLabelEncoder(object):
             skip_fitted and expand_mode are exclusive.
         """
         assert not (expand_mode and skip_fitted), "parameters expand_mode and skip_fitted are exclusive"
-        all_label_encoders = [self.word, self.char] + list(self.tasks.values())
+        lencs_to_update = self.all_label_encoders
         if expand_mode is True:
-            list_le_to_expand = [le for le in all_label_encoders if le.fitted is True]
-            list_le_to_fit = [le for le in all_label_encoders if le not in list_le_to_expand]
-            if list_le_to_fit:
+            lencs_to_expand = [le for le in lencs_to_update if le.fitted is True]
+            lencs_to_fit = [le for le in lencs_to_update if le not in lencs_to_expand]
+            if lencs_to_fit:
                 logger.warning(
-                    f"Expanding only the label encoders {list_le_to_expand} "
-                    f"and fitting the rest from scratch {list_le_to_fit}")
-            for le in list_le_to_expand:
+                    f"Expanding only the label encoders {lencs_to_expand} "
+                    f"and fitting the rest from scratch {lencs_to_fit}")
+            for le in lencs_to_expand:
                 le.fitted = False
         else:
             if skip_fitted:
-                all_label_encoders = [le for le in all_label_encoders if le.fitted is False]
-                if not all_label_encoders:
+                lencs_to_update = [le for le in lencs_to_update if le.fitted is False]
+                if not lencs_to_update:
                     logger.info("All label encoders have been fitted already !")
                     return self
-            list_le_to_expand = []
-            list_le_to_fit = all_label_encoders
+            lencs_to_expand = []
+            lencs_to_fit = lencs_to_update
 
         for inp in lines:
             tasks = None
@@ -521,20 +525,20 @@ class MultiLabelEncoder(object):
                 inp, tasks = inp
 
             # input
-            if self.word in all_label_encoders:
+            if self.word in lencs_to_update:
                 self.word.add(inp)
-            if self.char in all_label_encoders:
+            if self.char in lencs_to_update:
                 self.char.add(inp)
 
             for le in self.tasks.values():
-                if le not in all_label_encoders:
+                if le not in lencs_to_update:
                     continue
                 le.add(tasks[le.target], inp)
 
-        for le in list_le_to_fit:
+        for le in lencs_to_fit:
             le.compute_vocab()
         
-        for le in list_le_to_expand:
+        for le in lencs_to_expand:
             le.expand_vocab()
 
         if self.noise_strategies["uppercase"]["apply"]:

--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -242,6 +242,7 @@ class LabelEncoder(object):
 
         Important when using the upper strategy
         """
+        # Get all new uppercase chars of lowercase chars in the vocab
         inp = self.inverse_table[len(self.reserved):]
         new_chars = list(map(
             lambda x: x.upper(),
@@ -250,6 +251,11 @@ class LabelEncoder(object):
                 inp
             )
         ))
+
+        # Remove duplicates (in rare cases, multiple lowercase chars can have the same uppercasing)
+        new_chars = list(dict.fromkeys(new_chars))
+
+        # Reduce list of new chars to the number of available slots
         if self.max_size:
             t = len(self.inverse_table)
             r = len(self.reserved)
@@ -257,6 +263,8 @@ class LabelEncoder(object):
                 new_chars = new_chars[:min(len(new_chars), self.max_size-t-r)]
             else:
                 return # We have too much in the vocab already
+        
+        # Add new chars to the vocabulary
         self.inverse_table.extend(new_chars)
         self.table = {sym: idx for idx, sym in enumerate(self.inverse_table)}
 

--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -257,14 +257,17 @@ class LabelEncoder(object):
             t = len(self.inverse_table)
             r = len(self.reserved)
             slots_left = self.max_size - t - r
-            if slots_left > 0:
-                new_chars = new_chars[:min(len(new_chars), slots_left)]
+            if slots_left > 0:                
                 if slots_left < len(new_chars):
                     logger.info(f"Could not register all available uppercase vocab entries "
                                 f"({slots_left} slots < {len(new_chars)} upper chars)")
                 else:
                     logger.info(f"All uppercase ({self.name}) vocab registered ({len(new_chars)} new entries)")
+                new_chars = new_chars[:min(len(new_chars), slots_left)]
             else:
+                if len(new_chars) > 0:
+                    logger.info(f"Could not register all available uppercase vocab entries "
+                                f"({len(new_chars)} upper chars not registered)")
                 return # We have too much in the vocab already
         
         # Add new chars to the vocabulary

--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -256,7 +256,7 @@ class LabelEncoder(object):
             slots_left = self.max_size - len(self.inverse_table)
             if slots_left > 0:                
                 if slots_left < len(new_chars):
-                    logger.info(f"Could not register all available uppercase vocab entries "
+                    logger.info(f"Could not register all available uppercase {self.name} vocab entries "
                                 f"({slots_left} slots < {len(new_chars)} upper chars)")
                 else:
                     logger.info(f"All uppercase ({self.name}) vocab registered ({len(new_chars)} new entries)")
@@ -264,7 +264,7 @@ class LabelEncoder(object):
             else:
                 if len(new_chars) > 0:
                     logger.info(f"Could not register all available uppercase vocab entries "
-                                f"({len(new_chars)} upper chars not registered)")
+                                f"({len(new_chars)} upper {self.name} entries not registered)")
                 return # We have too much in the vocab already
         
         # Add new chars to the vocabulary

--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -256,8 +256,14 @@ class LabelEncoder(object):
         if self.max_size:
             t = len(self.inverse_table)
             r = len(self.reserved)
-            if (self.max_size - t - r) > 0:
-                new_chars = new_chars[:min(len(new_chars), self.max_size-t-r)]
+            slots_left = self.max_size - t - r
+            if slots_left > 0:
+                new_chars = new_chars[:min(len(new_chars), slots_left)]
+                if slots_left < len(new_chars):
+                    logger.info(f"Could not register all available uppercase vocab entries "
+                                f"({slots_left} slots < {len(new_chars)} upper chars)")
+                else:
+                    logger.info(f"All uppercase ({self.name}) vocab registered ({len(new_chars)} new entries)")
             else:
                 return # We have too much in the vocab already
         

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -124,6 +124,10 @@
   "load_pretrained_embeddings": "", // file with pretrained embeddings in word2vec format
   "load_pretrained_encoder": "", // path to file with pretrained sentence encoder
   "freeze_embeddings": false, // whether to freeze the word embeddings
+  "load_pretrained_model": {
+    "model_tar": "",
+    "exclude": []
+  }, // config to load a pretrained model
 
   // * Optimization
   "dropout": 0.0, // dropout

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -100,7 +100,7 @@
   // general task schedule params (can be overwritten in the "settings" entry of each)
   "patience": 100, // task patience (global early stopping patience for target task)
   "factor": 1, // default task schedule factor
-  "threshold": 0, // default task schedule thresholed
+  "threshold": 0, // default task schedule threshold
   "min_weight": 0, // default task schedule min_weight
 
   // * Joint LM-loss
@@ -124,11 +124,15 @@
   "load_pretrained_embeddings": "", // file with pretrained embeddings in word2vec format
   "load_pretrained_encoder": "", // path to file with pretrained sentence encoder
   "freeze_embeddings": false, // whether to freeze the word embeddings
-  "load_pretrained_model": {
+  "load_pretrained_model": {  // config to load a pretrained model
     "pretrained": "", // Path to the .tar file with the pretrained model
     "exclude": [],  // Modules to exclude from state_dict loading
-    "expand_labels": true  // whether expand label lists (word/char + tasks vocabs)
-  }, // config to load a pretrained model
+    "labels_mode": "expand"  // mode for creating the MultiLabelEncoder (word/char + tasks vocabs). 
+    // Options = {"expand", "skip", "replace"}:
+    // - "expand" expand existing pretrained label lists
+    // - "skip": only fit new encoders (for fine-tuning on a new task)
+    // - "replace": fit a new MultiLabelEncoder only with the finetuning data
+  }, 
 
   // * Optimization
   "dropout": 0.0, // dropout

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -6,6 +6,7 @@
   // * General
   "modelname": "model", // model name to be used for saving
   "modelpath": "./", // model path to be used for saving
+  "seed": "auto", // set a seed number or 'auto' to let the training script define it
 
   // * Data
   "input_path": "", // path (unix-like expression) to files with training data

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -130,9 +130,10 @@
     "exclude": [],  // Modules to exclude from state_dict loading
     "labels_mode": "expand"  // mode for creating the MultiLabelEncoder (word/char + tasks vocabs). 
     // Options = {"expand", "skip", "replace"}:
-    // - "expand" expand existing pretrained label lists
+    // - "expand" expand existing pretrained label lists with labels from the finetuning data (remaining spots, consider increasing vocab sizes)
     // - "skip": only fit new encoders (for fine-tuning on a new task)
     // - "replace": fit a new MultiLabelEncoder only with the finetuning data
+    // - "replace_fill": fit a new MultiLabelEncoder with the finetuning data, then fill the remaining spots with parent labels
   }, 
 
   // * Optimization

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -126,7 +126,8 @@
   "freeze_embeddings": false, // whether to freeze the word embeddings
   "load_pretrained_model": {
     "pretrained": "", // Path to the .tar file with the pretrained model
-    "exclude": []
+    "exclude": [],  // Modules to exclude from state_dict loading
+    "expand_labels": true  // whether expand label lists (word/char + tasks vocabs)
   }, // config to load a pretrained model
 
   // * Optimization

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -125,7 +125,7 @@
   "load_pretrained_encoder": "", // path to file with pretrained sentence encoder
   "freeze_embeddings": false, // whether to freeze the word embeddings
   "load_pretrained_model": {
-    "model_tar": "",
+    "pretrained": "", // Path to the .tar file with the pretrained model
     "exclude": []
   }, // config to load a pretrained model
 

--- a/pie/models/model.py
+++ b/pie/models/model.py
@@ -457,16 +457,16 @@ class SimpleModel(BaseModel):
                     label_encoder_pretrained,
                     state_dict_pretrained,
                     is_task=True,
-                    exclude_params_regex="^rnn"
+                    exclude_params_regex="^(rnn)|(attn)"
                 )
                 model_params_loaded.extend([f"{module_name}.{p}" for p in load_stats['params_updated']])
                 # Load decoder RNN params in block
                 module_name = f"{tname}_decoder.rnn"
-                params_updated = load_pretrained_module_in_block(self.encoder.rnn, module_name)
+                params_updated = load_pretrained_module_in_block(self.decoders[tname].rnn, module_name)
                 model_params_loaded.extend([f"{module_name}.{p}" for p in params_updated])
                 # Load decoder attn params in block
                 module_name = f"{tname}_decoder.attn"
-                params_updated = load_pretrained_module_in_block(self.encoder.rnn, module_name)
+                params_updated = load_pretrained_module_in_block(self.decoders[tname].attn, module_name)
                 model_params_loaded.extend([f"{module_name}.{p}" for p in params_updated])
             else:
                 raise NotImplementedError(f"Can only load decoder parameters for tasks with Linear Decoders (found {type(self.decoders[tname])})")

--- a/pie/scripts/group.py
+++ b/pie/scripts/group.py
@@ -101,11 +101,12 @@ def evaluate(model_path, test_path, train_path, settings, batch_size,
 
 @pie_cli.command("train")
 @click.argument('config_path')
-def train(config_path):
+@click.option('--seed', type=int, default=None)
+def train(config_path, seed):
     """ Train a model using the file at [CONFIG_PATH]"""
     import pie.scripts.train
     import pie.settings
-    pie.scripts.train.run(pie.settings.settings_from_file(config_path))
+    pie.scripts.train.run(pie.settings.settings_from_file(config_path), seed)
 
 
 @pie_cli.command("info")

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -125,7 +125,10 @@ def run(settings, seed=None):
     else:  # train from scratch or labels_mode== "replace"
         label_encoder = MultiLabelEncoder.from_settings(settings, tasks=tasks)
         if settings.verbose:
-            print("::: Fitting MultiLabelEncoder with data (replace mode) :::")
+            if settings.load_pretrained_model.get("pretrained"):
+                print("::: Fitting MultiLabelEncoder with data (replace mode) :::")
+            else:
+                print("::: Fitting MultiLabelEncoder with data :::")
             print()
         label_encoder.fit_reader(reader)
 

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -122,10 +122,10 @@ def run(settings):
     if settings.load_pretrained_encoder:
         model.init_from_encoder(pie.Encoder.load(settings.load_pretrained_encoder))
     
-    if settings.load_pretrained_model.get("model_tar"):
+    if settings.load_pretrained_model.get("pretrained"):
         print(f"Loading pretrained model {settings.load_pretrained_model['model_tar']}")
         model.load_state_dict_from_pretrained(
-            settings.load_pretrained_model["model_tar"],
+            settings.load_pretrained_model["pretrained"],
             settings.load_pretrained_model.get("exclude", [])
         )
 

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -58,23 +58,27 @@ def run(settings):
         print()
 
     # label encoder
-    if settings.load_pretrained_model.get("pretrained"):
+    labels_mode = settings.load_pretrained_model.get("labels_mode")
+    labels_mode_accepted = ["expand", "replace", "skip"]
+    assert labels_mode in labels_mode_accepted, \
+        f"Invalid value for labels_mode ({labels_mode}), accepted values are {labels_mode_accepted}"
+    if settings.load_pretrained_model.get("pretrained") and labels_mode != "replace":
         label_encoder = MultiLabelEncoder.load_from_pretrained_model(
             path=settings.load_pretrained_model["pretrained"],
             new_settings=settings,
             tasks=[t["name"] for t in settings.tasks]
         )
-        if settings.load_pretrained_model.get("expand_labels") is True:
+        if settings.load_pretrained_model.get("labels_mode") == "expand":
             if settings.verbose:
                 print("::: Fitting/Expanding MultiLabelEncoder with data :::")
                 print()
             label_encoder.fit_reader(reader, expand_mode=True)
-        else:
+        else:  # "skip"
             if settings.verbose:
                 print("::: Fitting MultiLabelEncoder with data (unfitted LabelEncoders only) :::")
                 print()
             label_encoder.fit_reader(reader, skip_fitted=True)
-    else:
+    else:  # train from scratch or labels_mode== "replace"
         label_encoder = MultiLabelEncoder.from_settings(settings, tasks=tasks)
         if settings.verbose:
             print("::: Fitting MultiLabelEncoder with data :::")

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -270,7 +270,16 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('config_path', nargs='?', default='config.json')
     parser.add_argument("--seed", type=int, default=None)
+    parser.add_argument('--opt_path', help='Path to optimization file (see opt.json)')
+    parser.add_argument('--n_iter', type=int, default=20, help="Number of iterations for the optimization mode")
     args = parser.parse_args()
 
     settings = settings_from_file(args.config_path)
-    run(settings, args.seed)
+
+    from pie import optimize
+
+    if args.opt_path:
+        opt = optimize.read_opt(args.opt_path)
+        optimize.run_optimize(run, settings, opt, args.n_iter)
+    else:
+        run(settings, args.seed)

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -4,6 +4,7 @@ import time
 import os
 from datetime import datetime
 import logging
+import warnings
 
 import pie
 from pie.settings import settings_from_file
@@ -117,9 +118,16 @@ def run(settings):
             initialization.init_pretrained_embeddings(
                 settings.load_pretrained_embeddings, label_encoder.word, model.wemb)
 
-    # load pretrained weights
+    # load weights from a pretrained encoder
     if settings.load_pretrained_encoder:
         model.init_from_encoder(pie.Encoder.load(settings.load_pretrained_encoder))
+    
+    if settings.load_pretrained_model.get("model_tar"):
+        print(f"Loading pretrained model {settings.load_pretrained_model['model_tar']}")
+        model.load_state_dict_from_pretrained(
+            settings.load_pretrained_model["model_tar"],
+            settings.load_pretrained_model.get("exclude", [])
+        )
 
     # freeze embeddings
     if settings.freeze_embeddings:

--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -32,11 +32,16 @@ def get_fname_infix(settings):
     return fname, infix
 
 
-def run(settings):
+def run(settings, seed):
     now = datetime.now()
 
     # set seed
-    seed = now.hour * 10000 + now.minute * 100 + now.second
+    if seed is None:
+        if settings.seed == "auto":
+            seed = now.hour * 10000 + now.minute * 100 + now.second
+        else:
+            seed = settings.seed
+            assert isinstance(seed, int), "Seed should be an integer"
     print("Using seed:", seed)
     random.seed(seed)
     numpy.random.seed(seed)

--- a/scripts/get_pie_model_params.py
+++ b/scripts/get_pie_model_params.py
@@ -1,0 +1,62 @@
+"""
+Script to print the architecture of a PIE model
+
+Usage: `python get_pie_model_params.py model.tar`
+"""
+
+import json
+import os
+import tarfile
+import sys
+
+import torch
+
+from pie import utils
+from pie.data import MultiLabelEncoder
+
+def load_model(tar_path):
+    """Custom function for this notebook, yet in PaPie need to add extra code blocks from the original Encoder.load() method:
+    - check tar_path extension
+    - check model and current commit values
+    - use get_gzip_from_tar function from utils
+    """
+    with tarfile.open(tar_path) as tar:
+        # load label encoder
+        label_encoder = MultiLabelEncoder.load_from_string(utils.get_gzip_from_tar(tar, 'label_encoder.zip'))
+
+        # load model parameters
+        params = json.loads(utils.get_gzip_from_tar(tar, 'parameters.zip'))
+
+        # load state_dict
+        with utils.tmpfile() as tmppath:
+            tar.extract('state_dict.pt', path=tmppath)
+            dictpath = os.path.join(tmppath, 'state_dict.pt')
+            state_dict = torch.load(dictpath, map_location='cpu')
+
+        return label_encoder, params, state_dict
+
+def show_model_architecture(tar_path):
+    label_encoder, model_params, state_dict = load_model(tar_path)
+    print(f"Label encoder:\n{label_encoder}\n")
+    print(f"Model params:\n{model_params}\n")
+    print(f"Model layers:\n{list(state_dict.keys())}")
+    wemb_dim, cemb_dim, hidden_size, num_layers = model_params["args"]
+    print(f"hidden_size: {hidden_size}")
+    print(f"num_layers: {num_layers}")
+    if "cemb.emb.weight" in state_dict:
+        char_vocab_size, char_emb_size = state_dict["cemb.emb.weight"].shape
+        assert cemb_dim == char_emb_size, \
+            (f"cemb_dim in parameters.zip differs from the actual model cemb_dim: "
+             f"{cemb_dim} != {char_emb_size}")
+        print(f"cemb_dim: {char_emb_size}")
+        print(f"Size of characters vocabulary (incl. 2 extra/default chars): {char_vocab_size}")
+    if wemb_dim:
+        print(f"wemb_dim: {wemb_dim}")
+    print(f"Size of words vocabulary (incl. 2 extra/default words): {len(label_encoder.word)}")
+    for task_name in label_encoder.tasks:
+        print(f"Number of labels for task {task_name} (incl. 1 extra/default label ??): {len(label_encoder.tasks[task_name].table)}")
+
+
+if __name__ == "__main__":
+    tar_path = sys.argv[1]
+    show_model_architecture(tar_path)


### PR DESCRIPTION
Implemented via a new config parameter `load_pretrained_model` and a new method `load_state_dict_from_pretrained()` in class `SimpleModel`.

Enable finetuning of another PaPie model by loading its state dict into the current model.

Customization of which parts to load is possible via the subparameter `load_pretrained_model["exclude"]`.

I already used my solution in an experiment in which I finetuned a PaPie POS tagger for Occitan, pretrained on a large synthetic dataset, finetuned with a smaller manually annotated dataset.

The results for the pretrained POS tagger are 91,19 / 82,72 / 89,24 (all tokens, unknown tokens, ambiguous tokens) ; the results of the finetuned POS tagger (tried only with one config, best of 5 runs): 92,64 / 86,14 / 91,02.

I can also confirm that the state_dicts were successfully loaded, as I can see in the logs:
```
Loading pretrained model
Initialized 106/111 char embs
Initialized 2748/9818 fwd LM word parameters
Initialized 2748/9818 bwd LM word parameters
```
Not all parameters of the LM layers could be updated because the vocabulary size has changed (20002 for the pretrained model vs. 9818 for the finetuned model).

(I also developped it in a notebook to observe the state_dict tensors in all loading steps)

By the way I noticed that the `load_pretrained_encoder` param might not be working, as I'm not sure that `pie.Encoder.load()` method can be called like this (`Encoder` doesn't seem to be imported in the `pie.__init__`), and this method calls `pie.dataset.MultiLabelEncoder`, yet `MultiLabelEncoder` seems to have moved to `pie.data.dataset.MultiLabelEncoder`.
Since my solution enables loading only the encoder of a model, should I try to change the code so that the parameter `load_pretrained_encoder` also points to the `load_state_dict_from_pretrained()` with `exclude=["lm", *tasks_names*]` ?