### PR TITLE
Sort vocab/labels by freq+alphabetically + enable simultaneous max_size+min_freq

### DIFF
--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -159,13 +159,13 @@ class LabelEncoder(object):
         # Sort freqs by order of frequency, and alphabetically in case of ties
         vocab = sorted(self.freqs.most_common(), key=lambda x: (-x[1], x[0]))
 
-        # Apply max_size
-        if self.max_size:
-            vocab = vocab[:self.max_size]
-
         # Apply min_freq
         if self.min_freq:
             vocab = [it for it in vocab if it[1] >= self.min_freq]
+
+        # Apply max_size
+        if self.max_size:
+            vocab = vocab[:self.max_size]
         
         # Remove frequencies
         vocab = [sym for sym, _ in vocab]

--- a/pie/data/dataset.py
+++ b/pie/data/dataset.py
@@ -156,14 +156,21 @@ class LabelEncoder(object):
             logging.warning("Computing vocabulary for empty encoder {}"
                             .format(self.name))
 
-        if self.max_size:
-            most_common = self.freqs.most_common(n=self.max_size)
-        elif self.min_freq:
-            most_common = [it for it in self.freqs.items() if it[1] >= self.min_freq]
-        else:
-            most_common = self.freqs.most_common()
+        # Sort freqs by order of frequency, and alphabetically in case of ties
+        vocab = sorted(self.freqs.most_common(), key=lambda x: (-x[1], x[0]))
 
-        self.inverse_table = list(self.reserved) + [sym for sym, _ in most_common]
+        # Apply max_size
+        if self.max_size:
+            vocab = vocab[:self.max_size]
+
+        # Apply min_freq
+        if self.min_freq:
+            vocab = [it for it in vocab if it[1] >= self.min_freq]
+        
+        # Remove frequencies
+        vocab = [sym for sym, _ in vocab]
+
+        self.inverse_table = list(self.reserved) + vocab
         self.table = {sym: idx for idx, sym in enumerate(self.inverse_table)}
         self.fitted = True
 

--- a/pie/default_settings.json
+++ b/pie/default_settings.json
@@ -21,11 +21,9 @@
   "max_sents": 1000000, // maximum number of sentences to process
   "word_max_size": 20000, // maximum vocabulary size for input word embeddings
   "word_min_freq": 1, // min freq of a word to be part of the vocabulary
-  // (only used if word_max_size is 0)
   "word_lower": false, // whether to lowercase input tokens
   "char_max_size": 500, // maximum vocabulary size for input character embeddings
   "char_min_freq": 1, // min freq of a character to be part of the vocabulary
-  // (only used if char_max_size is 0)
   "char_lower": false, // whether to lowercase input characters
   "char_eos": true, // whether to append char-level input with <eos>
   "char_bos": true, // whether to prepend char input input with <bos>


### PR DESCRIPTION
Currently, vocabs computed with no `max_size` and `min_freq>=1` (by default all tasks) are not sorted (i.e. kept in the order of data seen in the training dataset).

This PR proposes to make all vocabs (/labels lists) ordered by **frequency**, + **alphabetically** in case of ties. 

Also, the `max_size` and `min_freq` hyperparameters can now be used together to filter the list of vocab entries. Min_freq filtering is applied first to maximize the size of the vocabulary within the max_size limit.

Here are the reports of training with the `master` branch and the `vocab_sorting` branch: 
- master: [papie-lemma_toltb_sentlm_3_GRU_master_commit85fcc90_2589091.log](https://github.com/user-attachments/files/17560205/papie-lemma_toltb_sentlm_3_GRU_master_commit85fcc90_2589091.log)
- vocab_sorting: [papie-lemma_toltb_sentlm_3b_testvocabordering_commitf360104_2568457.log](https://github.com/user-attachments/files/17560208/papie-lemma_toltb_sentlm_3b_testvocabordering_commitf360104_2568457.log)

I tried to set a fixed seed but remembered it is not yet implemented in this repo (cf. this [commit](https://github.com/OrianeN/PaPie/commit/f9bbecfd91b5403387c53f7b805bf75152f73a99)), so the seeds indicated in the print of the configs doesn't correspond to the actual seeds used and printed below in the log files.

Note that I launched the runs before realizing filtering on min_freq should be done before max_size ; yet as min_freq is 1 in the config of both runs this should not affect the results.