### PR TITLE
Load best model + evaluate best model on devset

### DIFF
--- a/pie/scripts/train.py
+++ b/pie/scripts/train.py
@@ -152,8 +152,28 @@ def run(settings):
         model.eval()
     running_time = time.time() - running_time
 
+    # evaluate best model on devset
+    if settings.dev_path:
+        print()
+        print("Evaluating best model on dev set...")
+        print()
+        model.eval()
+        stored_scores = {}
+        with torch.no_grad():
+            dev_loss = trainer.evaluate(devset)
+            print()
+            print("::: Dev losses :::")
+            print()
+            print('\n'.join('{}: {:.4f}'.format(k, v) for k, v in dev_loss.items()))
+            print()
+            summary = model.evaluate(devset, trainer.dataset)
+            for task_name, scorer in summary.items():
+                stored_scores[task_name] = scorer.get_scores()
+                scorer.print_summary(scores=stored_scores[task_name])
+
+    # evaluate best model on test set
     if settings.test_path:
-        print("Evaluating model on test set")
+        print("Evaluating best model on test set")
         try:
             testset = Dataset(settings, Reader(settings, settings.test_path), label_encoder)
             for task in model.evaluate(testset, trainset).values():


### PR DESCRIPTION
I've noticed that the model loaded at the end of training differs whether the EarlyStoppingException was raised or not:
- if EarlyStoppingException: load best model
- otherwise, keep on with the last model

I'd like to suggest always loading the best model at the end of the training phase, as well as performing the final evaluation successively on the devset and on the testset (with the best model).

Logs of 2 runs to show you the changes in practice:
- without loading the best model: [papie_run_noloadbest.log](https://github.com/user-attachments/files/18503988/papie_run_noloadbest.log) (POS loss of the last model is higher than the one-but-last one)
- with loading the best model: [papie_run_loadbest.log](https://github.com/user-attachments/files/18503982/papie_run_loadbest.log)

Note: I've never tried training without a dev set, so I'm not sure about the comment at the end of the Trainer.train_epochs() function: 
https://github.com/OrianeN/PaPie/blob/d23f4a5e95638e74dad640cf7f1d44b896c2fb0e/pie/trainer.py#L429-L430